### PR TITLE
fix(tab): align tab headers with content when using Magic's Display List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes in this project are documented in this file.
 This project follows the conventions of Keep a Changelog and Semantic Versioning.
 
+## [0.3.1] - 2026-04-12
+
+### Fixed
+- **Tab index/content shifting with hidden tabs**: Updated the default `tab.ejs` (smartTabMatcher path) to support `WizlyActiveTabIndexes`, keeping tab headers and injected tab content aligned even when some tabs are omitted by Magic’s Display List filtering.
+
 ## [0.3.0] - 2026-03-29
 
 ### Added

--- a/docs/templates/tab.md
+++ b/docs/templates/tab.md
@@ -2,6 +2,18 @@
 
 Magic's base template for tab group.
 
+## Why this template is structured this way
+
+Magic Tab Controls work with an **Items List** (all possible tab pages) and a **Display List** (which tab indexes should be shown at runtime).
+
+The Magic Web Client typically generates a single HTML “source” that already reflects the Display List filtering: tabs that should not be shown are omitted from the rendered `<mat-tab>` headers. However, the tab page content (layers) is still associated with the original tab indexes.
+
+This mismatch can occur even without Wizly. It is a known Magic Web Client issue: when the generated tab headers are already filtered, the remaining tabs get renumbered by the UI, while the tab page content is still tied to the original tab indexes.
+
+When `smartTabMatcher` is enabled, Wizly extracts each `div.tab_content` layer and injects it into the corresponding `<mat-tab>` by index. If some tabs were omitted in the generated tab headers, Angular Material renumbers the remaining tabs, and the header index no longer matches the content index. The result is that tab headers and tab content can become misaligned (content “shifts”).
+
+The fix in the default template is: always generate the full set of possible tabs (based on extracted tab content), and then conditionally render each tab based on a Wizly-controlled “display list”. This preserves a stable tab index ↔ content mapping.
+
 ## Available Variables
 
 | Variable | Description | Source Attributes Searched |
@@ -45,29 +57,35 @@ Magic's base template for tab group.
 
 **Output with `smartTabMatcher: true`**
 ```html
+@let Tab14Raw = mg.getCustomProperty(mgc.Tab14, "WizlyActiveTabIndexes") || "";
+@let Tab14Wrapped = "," + Tab14Raw + ",";
 <mat-tab-group
     [magic]="mgc.Tab14"
     (selectedTabChange)="task.mgOnTabSelectionChanged(mgc.Tab14, $event.index)"
     [selectedIndex]="mg.getTabSelectedIndex(mgc.Tab14)"
 >
-    <mat-tab
-        [label]="
-            (mg.getItemListValues(mgc.Tab14) || []).length
-                ? mg.getTabpageText(mgc.Tab14, 1)
-                : ''
-        "
-    >
-        <!-- content of tab 1 -->
-    </mat-tab>
-    <mat-tab
-        [label]="
-            (mg.getItemListValues(mgc.Tab14) || []).length
-                ? mg.getTabpageText(mgc.Tab14, 2)
-                : ''
-        "
-    >
-        <!-- content of tab 2 -->
-    </mat-tab>
+    @if(!Tab14Raw || Tab14Wrapped.includes("," + 0 + ",")) {
+        <mat-tab
+            [label]="
+                (mg.getItemListValues(mgc.Tab14) || []).length
+                    ? mg.getTabpageText(mgc.Tab14, 0)
+                    : ''
+            "
+        >
+            <!-- content of tab 0 -->
+        </mat-tab>
+    }
+    @if(!Tab14Raw || Tab14Wrapped.includes("," + 1 + ",")) {
+        <mat-tab
+            [label]="
+                (mg.getItemListValues(mgc.Tab14) || []).length
+                    ? mg.getTabpageText(mgc.Tab14, 1)
+                    : ''
+            "
+        >
+            <!-- content of tab 1 -->
+        </mat-tab>
+    }
 </mat-tab-group>
 ```
 
@@ -86,12 +104,46 @@ module.exports = {
 ```
 
 The tab index is determined by the `isTabPageLayerSelected(mgc.TabX, N)` binding on the `div.tab_content`.
-Content is matched 1-based (Magic convention): tab index 1 maps to the first `mat-tab`, etc.
+Content is matched 0-based in Wizly's output: the first extracted tab page maps to index `0`, then `1`, etc.
 
 The `div.tab_content` blocks are removed from the HTML before any rules are applied, so the
 inner content passes through all transformation rules (label extraction, etc.) as normal.
 
-> **Note:** When `smartTabMatcher` is active, each `mat-tab` is generated statically (one per tab page).
-> The dynamic `@for` loop is only used when no tab content is available.
-> If `getItemListValues` conditionally excludes tabs at runtime, those tabs will still appear in the
-> generated output — this is a known limitation to address in a future version.
+## `WizlyActiveTabIndexes` (optional)
+
+You can set a custom property on the tab-group: `WizlyActiveTabIndexes`.
+
+- Value: a comma-separated string of indexes starting from `0` (e.g. `1,2`). Treat this as the Wizly equivalent of Magic’s Tab Control “Display List”.
+- Behavior:
+  - Empty/undefined: all tabs are rendered.
+  - Provided: only indexes present in the string are rendered (and only that content is present in the DOM).
+
+The template wraps the string as `"," + raw + ","` so checks like `includes(",1,")` avoid false positives (e.g. `1` should not match inside `10`).
+
+This intentionally does not use Magic’s “Visible Layers List”. The goal is to re-apply the Display List concept at template time, after all possible tabs have been generated, so Angular Material indexes and injected content cannot drift apart.
+
+## Angular version compatibility
+
+The default templates use Angular control flow (`@for`, `@if`, `@let`) and are intended for Angular 17+.
+
+### Fallback template for Angular 16 and below
+
+If you cannot use `@let` yet, you can achieve the same behavior with `*ngIf` (not pretty, but workable). Conceptually it’s identical; you just repeat the `mg.getCustomProperty(...)` call.
+
+```html
+<mat-tab-group
+    [magic]="mgc.Tab14"
+    (selectedTabChange)="task.mgOnTabSelectionChanged(mgc.Tab14, $event.index)"
+    [selectedIndex]="mg.getTabSelectedIndex(mgc.Tab14)"
+>
+    <mat-tab
+        *ngIf="
+            !mg.getCustomProperty(mgc.Tab14, 'WizlyActiveTabIndexes') ||
+            (',' + (mg.getCustomProperty(mgc.Tab14, 'WizlyActiveTabIndexes') || '') + ',').includes(',0,')
+        "
+        [label]="(mg.getItemListValues(mgc.Tab14) || []).length ? mg.getTabpageText(mgc.Tab14, 0) : ''"
+    >
+        <!-- content of tab 0 -->
+    </mat-tab>
+</mat-tab-group>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wizly",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wizly",
-      "version": "0.2.1",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "ejs": "^4.0.1",
@@ -29,7 +29,7 @@
         "typescript": "^5.9.2"
       },
       "engines": {
-        "vscode": "^1.103.0"
+        "vscode": "^1.109.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wizly",
   "displayName": "Wizly",
   "description": "Automatically post-process Magic xpa Web Client generated HTML to improve quality and optionally switch to other UI frameworks via regex — no manual edits.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "sybrenvanzon",
   "license": "MIT",
   "repository": {

--- a/src/test/fixtures/expected/tab-full.html
+++ b/src/test/fixtures/expected/tab-full.html
@@ -1,33 +1,40 @@
+@let Tab1Raw = mg.getCustomProperty(mgc.Tab1, "WizlyActiveTabIndexes") || "";
+@let Tab1Wrapped = "," + Tab1Raw + ",";
+
 <mat-tab-group
   [magic]="mgc.Tab1"
   (selectedTabChange)="task.mgOnTabSelectionChanged(mgc.Tab1, $event.index)"
   [selectedIndex]="mg.getTabSelectedIndex(mgc.Tab1)"
 >
-  <mat-tab
-    [label]="
-      (mg.getItemListValues(mgc.Tab1) || []).length
-        ? mg.getTabpageText(mgc.Tab1, 0)
-        : ''
-    "
-  >
-    <div class="d-flex flex-row">
-      <span>
-        {{ mg.getText(mgc.Label2) }}
-      </span>
-    </div>
-  </mat-tab>
+  @if (!Tab1Raw || Tab1Wrapped.includes("," + 0 + ",")) {
+    <mat-tab
+      [label]="
+        (mg.getItemListValues(mgc.Tab1) || []).length
+          ? mg.getTabpageText(mgc.Tab1, 0)
+          : ''
+      "
+    >
+      <div class="d-flex flex-row">
+        <span>
+          {{ mg.getText(mgc.Label2) }}
+        </span>
+      </div>
+    </mat-tab>
+  }
 
-  <mat-tab
-    [label]="
-      (mg.getItemListValues(mgc.Tab1) || []).length
-        ? mg.getTabpageText(mgc.Tab1, 1)
-        : ''
-    "
-  >
-    <div class="d-flex flex-row">
-      <span>
-        {{ mg.getText(mgc.Label3) }}
-      </span>
-    </div>
-  </mat-tab>
+  @if (!Tab1Raw || Tab1Wrapped.includes("," + 1 + ",")) {
+    <mat-tab
+      [label]="
+        (mg.getItemListValues(mgc.Tab1) || []).length
+          ? mg.getTabpageText(mgc.Tab1, 1)
+          : ''
+      "
+    >
+      <div class="d-flex flex-row">
+        <span>
+          {{ mg.getText(mgc.Label3) }}
+        </span>
+      </div>
+    </mat-tab>
+  }
 </mat-tab-group>

--- a/templates/tab.ejs
+++ b/templates/tab.ejs
@@ -1,3 +1,11 @@
+<%
+    const tabName = magic.replace(/^mgc\./, '');
+    const tabPages = tabPageContent && tabPageContent[tabName];
+%>
+<% if (tabPages) { %>
+@let <%= tabName %>Raw = (mg.getCustomProperty(<%= magic %>, 'WizlyActiveTabIndexes') || '');
+@let <%= tabName %>Wrapped = ',' + <%= tabName %>Raw + ',';
+<% } %>
 <mat-tab-group
     [magic]="<%= magic %>"
     (selectedTabChange)="task.mgOnTabSelectionChanged(<%= magic %>, $event.index)"
@@ -6,15 +14,15 @@
     <% if (attrTooltip) { %>[matTooltip]="<%= attrTooltip %>"<% } %>
 >
 <%
-    const tabName = magic.replace(/^mgc\./, '');
-    const tabPages = tabPageContent && tabPageContent[tabName];
     if (tabPages) {
         for (let i = 0; i < tabPages.length; i++) {
 %>
-    <mat-tab [label]="(mg.getItemListValues(<%= magic %>) || []).length ? mg.getTabpageText(<%= magic %>, <%= i %>): ''">
-        <%- tabPages[i] %>
-    </mat-tab>
-<%  }
+    @if(!<%= tabName %>Raw || <%= tabName %>Wrapped.includes(',' + <%= i %> + ',')) {
+        <mat-tab [label]="(mg.getItemListValues(<%= magic %>) || []).length ? mg.getTabpageText(<%= magic %>, <%= i %>): ''">
+            <%- tabPages[i] %>
+        </mat-tab>
+    }
+<%      }
     } else {
 %>
     @for(o of mg.getItemListValues(<%= magic %>); track o) {


### PR DESCRIPTION
Add support for WizlyActiveTabIndexes custom property to conditionally render tabs. This prevents tab content shifting when Magic's Display List filters out some tabs at generation time, ensuring headers and injected content remain aligned. Update template, documentation, and version to 0.3.1.