### PR TITLE
feat: add in-app release notes popup after updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes in this project are documented in this file.
 This project follows the conventions of Keep a Changelog and Semantic Versioning.
 
+## [0.4.0] - 2026-06-28
+
+### Added
+- **In-app release notes on update**: Wizly now stores the previously installed extension version and, after an update, looks for `release-notes/<version>.md`. When a matching file exists, Wizly shows a compact popup summary and lets the user open `CHANGELOG.md` for the full list of changes.
+- **Preparation for 1.0.0 communication**: This release adds the foundation for clearly communicating the larger set of upcoming `1.0.0` changes, so important improvements are not silently auto-installed without context.
+
 ## [0.3.1] - 2026-04-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wizly",
   "displayName": "Wizly",
   "description": "Automatically post-process Magic xpa Web Client generated HTML to improve quality and optionally switch to other UI frameworks via regex — no manual edits.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "publisher": "sybrenvanzon",
   "license": "MIT",
   "repository": {
@@ -45,6 +45,7 @@
   ],
   "main": "./dist/extension.js",
   "activationEvents": [
+    "onStartupFinished",
     "onLanguage:html",
     "workspaceContains:.vswizly.js",
     "workspaceContains:.vswizly/wizly.config.js"

--- a/release-notes/0.4.0.md
+++ b/release-notes/0.4.0.md
@@ -1,0 +1,5 @@
+# Wizly 0.4.0
+
+- Added a popup summary with a button to open the changelog for the full list of changes.
+- This popup only shows the most important highlights; all changes are listed in `CHANGELOG.md`.
+- This feature is introduced now so the upcoming `1.0.0` can clearly explain its larger set of new features instead of arriving silently through auto-update.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,11 +7,278 @@ import { refreshModes, getModes, getCachedSettings } from './config';
 import { transformText } from './transformer';
 
 let outputChannel: vscode.OutputChannel | null = null;
+const EXTENSION_VERSION_STATE_KEY = 'wizly.extensionVersion';
+
 function getOutputChannel(): vscode.OutputChannel {
     if (!outputChannel) {
         outputChannel = vscode.window.createOutputChannel('Wizly');
     }
     return outputChannel;
+}
+
+type ReleaseNotesInfo = {
+    version: string;
+    previousVersion?: string;
+    relativePath: string;
+    summaryMarkdown: string;
+};
+
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function getReleaseNotesFilePath(context: vscode.ExtensionContext, version: string): string {
+    return path.join(context.extension.extensionPath, 'release-notes', `${version}.md`);
+}
+
+function getChangelogFilePath(context: vscode.ExtensionContext): string {
+    return path.join(context.extension.extensionPath, 'CHANGELOG.md');
+}
+
+function findReleaseNotesFilePath(context: vscode.ExtensionContext, version: string): string | undefined {
+    const candidates = [version];
+    const baseVersion = version.replace(/-rc\d+$/i, '');
+    if (baseVersion && baseVersion !== version) {
+        candidates.push(baseVersion);
+    }
+
+    for (const candidate of candidates) {
+        const filePath = getReleaseNotesFilePath(context, candidate);
+        if (fs.existsSync(filePath)) {
+            return filePath;
+        }
+    }
+
+    return undefined;
+}
+
+function renderInlineMarkdownToHtml(text: string): string {
+    let html = escapeHtml(text);
+    html = html.replace(/\[([^\]]+)\]\(((?:https?:\/\/|file:\/\/)[^)]+)\)/g, '<a href="$2">$1</a>');
+    html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+    html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    return html;
+}
+
+function renderMarkdownExcerptToHtml(markdown: string): string {
+    const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+    const htmlParts: string[] = [];
+    let paragraphLines: string[] = [];
+    let listItems: string[] = [];
+    let codeLines: string[] = [];
+    let inCodeBlock = false;
+
+    const flushParagraph = () => {
+        if (paragraphLines.length === 0) { return; }
+        htmlParts.push(`<p>${renderInlineMarkdownToHtml(paragraphLines.join(' '))}</p>`);
+        paragraphLines = [];
+    };
+
+    const flushList = () => {
+        if (listItems.length === 0) { return; }
+        htmlParts.push(`<ul>${listItems.map(item => `<li>${item}</li>`).join('')}</ul>`);
+        listItems = [];
+    };
+
+    const flushCodeBlock = () => {
+        if (codeLines.length === 0) { return; }
+        htmlParts.push(`<pre><code>${escapeHtml(codeLines.join('\n'))}</code></pre>`);
+        codeLines = [];
+    };
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+
+        if (/^```/.test(trimmed)) {
+            flushParagraph();
+            flushList();
+            if (inCodeBlock) {
+                flushCodeBlock();
+                inCodeBlock = false;
+            } else {
+                inCodeBlock = true;
+            }
+            continue;
+        }
+
+        if (inCodeBlock) {
+            codeLines.push(line);
+            continue;
+        }
+
+        if (!trimmed) {
+            flushParagraph();
+            flushList();
+            continue;
+        }
+
+        const headingMatch = trimmed.match(/^(#{1,3})\s+(.*)$/);
+        if (headingMatch) {
+            flushParagraph();
+            flushList();
+            const level = Math.min(3, headingMatch[1].length);
+            htmlParts.push(`<h${level}>${renderInlineMarkdownToHtml(headingMatch[2].trim())}</h${level}>`);
+            continue;
+        }
+
+        const listMatch = trimmed.match(/^[-*]\s+(.*)$/);
+        if (listMatch) {
+            flushParagraph();
+            listItems.push(renderInlineMarkdownToHtml(listMatch[1].trim()));
+            continue;
+        }
+
+        paragraphLines.push(trimmed);
+    }
+
+    flushParagraph();
+    flushList();
+    flushCodeBlock();
+
+    return htmlParts.join('\n');
+}
+
+function escapeRegExp(text: string): string {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function openChangelogForVersion(context: vscode.ExtensionContext, version: string): Promise<void> {
+    const changelogPath = getChangelogFilePath(context);
+    const doc = await vscode.workspace.openTextDocument(changelogPath);
+    const editor = await vscode.window.showTextDocument(doc, { preview: false });
+    const lines = doc.getText().split(/\r?\n/);
+    const candidates = [version];
+    const baseVersion = version.replace(/-rc\d+$/i, '');
+    if (baseVersion && baseVersion !== version) {
+        candidates.push(baseVersion);
+    }
+
+    for (const candidate of candidates) {
+        const pattern = new RegExp(`^## \\[${escapeRegExp(candidate)}\\]\\b`);
+        const lineIndex = lines.findIndex(line => pattern.test(line));
+        if (lineIndex >= 0) {
+            const position = new vscode.Position(lineIndex, 0);
+            const range = new vscode.Range(position, position);
+            editor.selection = new vscode.Selection(position, position);
+            editor.revealRange(range, vscode.TextEditorRevealType.AtTop);
+            return;
+        }
+    }
+}
+
+async function showReleaseNotesPanel(context: vscode.ExtensionContext, notes: ReleaseNotesInfo): Promise<void> {
+    const panel = vscode.window.createWebviewPanel(
+        'wizlyReleaseNotes',
+        `Wizly: What's New in ${notes.version}`,
+        vscode.ViewColumn.Active,
+        { enableScripts: true, retainContextWhenHidden: false }
+    );
+    const nonce = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const fromText = notes.previousVersion
+        ? `Wizly updated from ${escapeHtml(notes.previousVersion)} to ${escapeHtml(notes.version)}.`
+        : `Wizly updated to ${escapeHtml(notes.version)}.`;
+    const summaryHtml = renderMarkdownExcerptToHtml(notes.summaryMarkdown);
+
+    panel.webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${panel.webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wizly Release Notes</title>
+  <style>
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); background: var(--vscode-editor-background); padding: 20px; line-height: 1.55; }
+    h1, h2, h3 { margin: 0 0 12px; line-height: 1.25; }
+    p { margin: 0 0 12px; }
+    ul { margin: 0 0 16px 18px; padding: 0; }
+    li { margin: 0 0 8px; }
+    code { font-family: var(--vscode-editor-font-family, monospace); background: var(--vscode-textCodeBlock-background, rgba(127,127,127,0.12)); padding: 2px 4px; border-radius: 4px; }
+    pre { overflow-x: auto; padding: 12px; border-radius: 8px; background: var(--vscode-textCodeBlock-background, rgba(127,127,127,0.12)); }
+    a { color: var(--vscode-textLink-foreground); }
+    .eyebrow { color: var(--vscode-descriptionForeground); margin-bottom: 16px; }
+    .shell { max-width: 860px; margin: 0 auto; }
+    .card { border: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.2)); border-radius: 10px; padding: 18px; background: var(--vscode-sideBar-background, var(--vscode-editor-background)); }
+    .meta { color: var(--vscode-descriptionForeground); font-size: 12px; margin-top: 18px; }
+    .button-row { display: flex; gap: 10px; margin-top: 20px; flex-wrap: wrap; }
+    button { padding: 8px 14px; border: 1px solid var(--vscode-button-border, transparent); border-radius: 6px; cursor: pointer; }
+    #openButton { color: var(--vscode-button-foreground); background: var(--vscode-button-background); }
+    #dismissButton { color: var(--vscode-button-secondaryForeground, var(--vscode-foreground)); background: var(--vscode-button-secondaryBackground, transparent); }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <div class="eyebrow">${fromText}</div>
+    <div class="card">
+      ${summaryHtml}
+      <div class="button-row">
+        <button id="openButton" type="button">Open Changelog</button>
+        <button id="dismissButton" type="button">Close</button>
+      </div>
+      <div class="meta">Summary source: ${escapeHtml(notes.relativePath)}</div>
+    </div>
+  </div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    document.getElementById('openButton')?.addEventListener('click', () => {
+      vscode.postMessage({ command: 'openChangelog' });
+    });
+    document.getElementById('dismissButton')?.addEventListener('click', () => {
+      vscode.postMessage({ command: 'dismiss' });
+    });
+  </script>
+</body>
+</html>`;
+
+    const messageSubscription = panel.webview.onDidReceiveMessage(async (message) => {
+        if (message?.command === 'openChangelog') {
+            await openChangelogForVersion(context, notes.version);
+            return;
+        }
+
+        if (message?.command === 'dismiss') {
+            panel.dispose();
+        }
+    });
+
+    panel.onDidDispose(() => {
+        messageSubscription.dispose();
+    });
+
+    context.subscriptions.push(panel);
+}
+
+async function maybeShowReleaseNotesForExtensionUpdate(context: vscode.ExtensionContext): Promise<void> {
+    try {
+        const currentVersionRaw = context.extension.packageJSON?.version;
+        const currentVersion = typeof currentVersionRaw === 'string' ? currentVersionRaw.trim() : '';
+        if (!currentVersion) { return; }
+
+        const previousVersion = context.globalState.get<string>(EXTENSION_VERSION_STATE_KEY);
+        if (previousVersion === currentVersion) { return; }
+
+        await context.globalState.update(EXTENSION_VERSION_STATE_KEY, currentVersion);
+        if (!previousVersion) { return; }
+
+        const releaseNotesPath = findReleaseNotesFilePath(context, currentVersion);
+        if (!releaseNotesPath) { return; }
+
+        const summaryMarkdown = fs.readFileSync(releaseNotesPath, 'utf8').replace(/\r\n/g, '\n').trim()
+            || `# Wizly ${currentVersion}\n\nSee \`CHANGELOG.md\` for the full list of changes.`;
+
+        await showReleaseNotesPanel(context, {
+            version: currentVersion,
+            previousVersion,
+            relativePath: path.relative(context.extension.extensionPath, releaseNotesPath).replace(/\\/g, '/'),
+            summaryMarkdown
+        });
+    } catch (error) {
+        getOutputChannel().appendLine(`Wizly: Failed to show release notes. ${error instanceof Error ? error.message : String(error)}`);
+    }
 }
 
 // Get uncommitted files from Git
@@ -390,6 +657,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(openConfigDisposable);
 
     updateStatusBar();
+    void maybeShowReleaseNotesForExtensionUpdate(context);
 
     // File watcher to clear cache on config change
     const watcher = vscode.workspace.createFileSystemWatcher('**/.vswizly/*.js');


### PR DESCRIPTION
bump package version to 0.4.0, add release-notes/0.4.0.md summary file, update CHANGELOG.md with full 0.4.0 release notes, add onStartupFinished activation event to run update checks on extension startup, show users a summary of changes after each update, and lay groundwork for clear 1.0.0 feature communication without silent auto-updates.